### PR TITLE
Fix d3 json problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
       "plugin:vue/essential",
       "eslint:recommended"
     ],
-    "rules": {},
+    "rules": {
+      "no-console": "off"
+    },
     "parserOptions": {
       "parser": "babel-eslint"
     }

--- a/src/components/barChart.vue
+++ b/src/components/barChart.vue
@@ -96,7 +96,7 @@ export default {
                     .style("display", "inline-block")
                     .html((d.area) + "<br>" + "£" + (d.value));
                 })
-                .on("mouseout", function(d){ 
+                .on("mouseout", function(){ 
                     tooltip.style("display", "none");
                 });          
             }

--- a/src/views/interface.vue
+++ b/src/views/interface.vue
@@ -35,11 +35,9 @@ export default {
   methods: {
         fetchData() {
             console.log("Inside fetchData() !!!!");
-            d3.json("../barchart.json", function(error, data) {
+            d3.json("/barchart.json").then(data => {
                 console.log("\nInside d3.json()!!!!\n");
-                if (error){
-                    throw error;  
-                }                        
+                console.log(data);                
                 this.barchart_data = data;
                 // debug
                 console.log("this.barchart_data: ", this.barchart_data);


### PR DESCRIPTION
Problem:
1. In d3 version 5, we need to use Promise. https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50
2. We need to use arrow function or bind function to bind ```this``` to the function, such that ```this.barchart_data = data;``` works. 

Solution:
1. Use Promise
```
d3.json("/barchart.json").then(function(data) {
  ...
});
```
2. Use arrow function
 ```
d3.json("/barchart.json").then(data => {
  ...
});
```